### PR TITLE
fix npm start error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "start": "roadhog server",
+    "start": "roadhog buildDll && roadhog server",
     "build": "roadhog build",
     "build:dll": "roadhog buildDll",
     "test": "roadhog test",


### PR DESCRIPTION
I clone the origin repo, and then 'npm install', and then 'npm start', and then error cccured!  Need to run 'roadhog buildDll' bebofe 'roadhog server'.This PR fixes the error.